### PR TITLE
Allow retrieval for .clu.X files from gui

### DIFF
--- a/gebaSpike/core/gui_utils.py
+++ b/gebaSpike/core/gui_utils.py
@@ -161,10 +161,15 @@ def find_tetrodes(self, set_fullpath):
         tetrode_list = [os.path.join(tetrode_path, file) for file in file_list
                         if is_tetrode(file, session)]
 
-        # if the .cut file doesn't exist remove list
-
-        tetrode_list = [file for file in tetrode_list if os.path.exists(
-            os.path.join(tetrode_path, '%s_%s.cut' % (os.path.splitext(file)[0], os.path.splitext(file)[1][1:])))]
+        # if the .cut or .clu.X file doesn't exist remove from list
+        tetrode_list = [file for file in tetrode_list if (
+            os.path.exists(
+                os.path.join(tetrode_path, '%s_%s.cut' % (
+                    os.path.splitext(file)[0], os.path.splitext(file)[1][1:]))) or
+            os.path.exists(
+                os.path.join(tetrode_path, '%s.clu.%s' % (
+                    os.path.splitext(file)[0], os.path.splitext(file)[1][1:])))
+        )]
 
         tetrode_files[file] = tetrode_list
 

--- a/gebaSpike/main.py
+++ b/gebaSpike/main.py
@@ -838,8 +838,14 @@ class MainWindow(QtWidgets.QWidget):
             except ValueError:
                 return
 
-            cut_filename = '%s_%d.cut' % (os.path.splitext(filename)[0], tetrode)
-            self.cut_filename.setText(os.path.realpath(cut_filename))
+            cut_filename = '%s_%d.cut' % (
+                os.path.splitext(filename)[0], tetrode)
+            clu_filename = '%s.clu.%d' % (
+                os.path.splitext(filename)[0], tetrode)
+            if os.path.exists(cut_filename):
+                self.cut_filename.setText(os.path.realpath(cut_filename))
+            elif os.path.exists(clu_filename):
+                self.cut_filename.setText(os.path.realpath(clu_filename))
 
     def tetrode_changed(self):
         """


### PR DESCRIPTION
Hi Geoff,

We were using gebaSpike with .clu.X files instead of .cut files. gebaSpike seemed to be able to handle reading these files perfectly fine from the code, but they were not being picked up by the UI. The changes below fixed this for us, so I thought I would send them along!

The change to gui_utils.py should keep tetrodes files to analyse if they have a .cut file or a .clu.X file associated with them.

The change to main.py should allow for automatic .clu.X file name setting as well as .cut files.

In both cases .cut files are prioritised over .clu.X files if both exist.